### PR TITLE
Implement NRF24L01 quiz-style button system

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,26 @@
-# 4_Btn_Qst
+# 4 Button Quiz System
+
+This repository contains Arduino sketches for a simple quiz-style button system using
+nRF24L01 radios.
+
+## Components
+
+- Four battery-powered remote units (`remote_button1` to `remote_button4`).
+  Each remote has a single push button and an nRF24L01 module.
+- One main controller (`main_controller`) with four LEDs and a reset button.
+
+## Behaviour
+
+1. On start-up the main controller enables all remote buttons.
+2. The first remote button pressed causes the corresponding LED on the main
+   controller to light. All other remotes are disabled.
+3. Pressing the reset button on the main controller turns off all LEDs and
+   re-enables all remotes.
+
+Remote sketches ignore button presses until an enable command is received from
+the main controller, which helps conserve battery power.
+
+Upload the appropriate sketch to each Arduino Nano. All sketches assume the
+nRF24L01 is connected with CE on pin 9 and CSN on pin 10.
+
+

--- a/src/main_controller/main_controller.ino
+++ b/src/main_controller/main_controller.ino
@@ -1,0 +1,73 @@
+#include <RF24.h>
+
+// nRF24L01 pins: CE on 9, CSN on 10
+RF24 radio(9, 10);
+
+const byte ADDRESSES[4][6] = {"BTN1", "BTN2", "BTN3", "BTN4"};
+
+const int LED_PINS[4] = {2, 3, 4, 5};
+const int RESET_PIN = 6;
+
+enum Command : uint8_t {
+  CMD_DISABLE = 0,
+  CMD_ENABLE = 1
+};
+
+int winner = -1;
+
+void broadcastCommand(Command cmd) {
+  radio.stopListening();
+  for (int i = 0; i < 4; i++) {
+    radio.openWritingPipe(ADDRESSES[i]);
+    radio.write(&cmd, sizeof(cmd));
+  }
+  radio.startListening();
+}
+
+void resetGame() {
+  for (int i = 0; i < 4; i++) {
+    digitalWrite(LED_PINS[i], LOW);
+  }
+  winner = -1;
+  broadcastCommand(CMD_ENABLE);
+}
+
+void setup() {
+  for (int i = 0; i < 4; i++) {
+    pinMode(LED_PINS[i], OUTPUT);
+  }
+  pinMode(RESET_PIN, INPUT_PULLUP);
+
+  radio.begin();
+  radio.setPALevel(RF24_PA_LOW);
+  radio.setDataRate(RF24_250KBPS);
+
+  // Open reading pipes for each remote
+  for (int i = 0; i < 4; i++) {
+    radio.openReadingPipe(i + 1, ADDRESSES[i]);
+  }
+  radio.startListening();
+
+  resetGame(); // Send initial enable and clear LEDs
+}
+
+void loop() {
+  uint8_t pipe;
+  if (radio.available(&pipe)) {
+    uint8_t msg;
+    radio.read(&msg, sizeof(msg));
+    int idx = pipe - 1;
+    if (winner < 0 && idx >= 0 && idx < 4) {
+      winner = idx;
+      digitalWrite(LED_PINS[idx], HIGH);
+      broadcastCommand(CMD_DISABLE);
+    }
+  }
+
+  // Reset button logic
+  if (digitalRead(RESET_PIN) == LOW) {
+    resetGame();
+    delay(200); // simple debounce
+  }
+}
+

--- a/src/remote_button1/remote_button1.ino
+++ b/src/remote_button1/remote_button1.ino
@@ -1,0 +1,47 @@
+#include <RF24.h>
+
+// nRF24L01 pins: CE on 9, CSN on 10
+RF24 radio(9, 10);
+
+const byte ADDRESS[6] = "BTN1"; // Unique pipe address for this node
+
+const int BUTTON_PIN = 2;
+
+// Commands
+enum Command : uint8_t {
+  CMD_DISABLE = 0,
+  CMD_ENABLE = 1
+};
+
+bool enabled = false;
+
+void setup() {
+  pinMode(BUTTON_PIN, INPUT_PULLUP);
+
+  radio.begin();
+  radio.setPALevel(RF24_PA_LOW);
+  radio.setDataRate(RF24_250KBPS);
+  radio.openWritingPipe(ADDRESS);
+  radio.openReadingPipe(1, ADDRESS);
+  radio.startListening();
+}
+
+void loop() {
+  // Check for enable/disable commands from the main controller
+  if (radio.available()) {
+    uint8_t cmd;
+    radio.read(&cmd, sizeof(cmd));
+    enabled = (cmd == CMD_ENABLE);
+  }
+
+  // When enabled, report the button press once
+  if (enabled && digitalRead(BUTTON_PIN) == LOW) {
+    radio.stopListening();
+    uint8_t msg = 1; // This node's ID
+    radio.write(&msg, sizeof(msg));
+    radio.startListening();
+    enabled = false; // ignore further presses until re-enabled
+    delay(50); // basic debounce
+  }
+}
+

--- a/src/remote_button2/remote_button2.ino
+++ b/src/remote_button2/remote_button2.ino
@@ -1,0 +1,43 @@
+#include <RF24.h>
+
+RF24 radio(9, 10);
+
+const byte ADDRESS[6] = "BTN2"; // Unique pipe address for this node
+
+const int BUTTON_PIN = 2;
+
+enum Command : uint8_t {
+  CMD_DISABLE = 0,
+  CMD_ENABLE = 1
+};
+
+bool enabled = false;
+
+void setup() {
+  pinMode(BUTTON_PIN, INPUT_PULLUP);
+
+  radio.begin();
+  radio.setPALevel(RF24_PA_LOW);
+  radio.setDataRate(RF24_250KBPS);
+  radio.openWritingPipe(ADDRESS);
+  radio.openReadingPipe(1, ADDRESS);
+  radio.startListening();
+}
+
+void loop() {
+  if (radio.available()) {
+    uint8_t cmd;
+    radio.read(&cmd, sizeof(cmd));
+    enabled = (cmd == CMD_ENABLE);
+  }
+
+  if (enabled && digitalRead(BUTTON_PIN) == LOW) {
+    radio.stopListening();
+    uint8_t msg = 2; // This node's ID
+    radio.write(&msg, sizeof(msg));
+    radio.startListening();
+    enabled = false;
+    delay(50);
+  }
+}
+

--- a/src/remote_button3/remote_button3.ino
+++ b/src/remote_button3/remote_button3.ino
@@ -1,0 +1,43 @@
+#include <RF24.h>
+
+RF24 radio(9, 10);
+
+const byte ADDRESS[6] = "BTN3"; // Unique pipe address for this node
+
+const int BUTTON_PIN = 2;
+
+enum Command : uint8_t {
+  CMD_DISABLE = 0,
+  CMD_ENABLE = 1
+};
+
+bool enabled = false;
+
+void setup() {
+  pinMode(BUTTON_PIN, INPUT_PULLUP);
+
+  radio.begin();
+  radio.setPALevel(RF24_PA_LOW);
+  radio.setDataRate(RF24_250KBPS);
+  radio.openWritingPipe(ADDRESS);
+  radio.openReadingPipe(1, ADDRESS);
+  radio.startListening();
+}
+
+void loop() {
+  if (radio.available()) {
+    uint8_t cmd;
+    radio.read(&cmd, sizeof(cmd));
+    enabled = (cmd == CMD_ENABLE);
+  }
+
+  if (enabled && digitalRead(BUTTON_PIN) == LOW) {
+    radio.stopListening();
+    uint8_t msg = 3; // This node's ID
+    radio.write(&msg, sizeof(msg));
+    radio.startListening();
+    enabled = false;
+    delay(50);
+  }
+}
+

--- a/src/remote_button4/remote_button4.ino
+++ b/src/remote_button4/remote_button4.ino
@@ -1,0 +1,43 @@
+#include <RF24.h>
+
+RF24 radio(9, 10);
+
+const byte ADDRESS[6] = "BTN4"; // Unique pipe address for this node
+
+const int BUTTON_PIN = 2;
+
+enum Command : uint8_t {
+  CMD_DISABLE = 0,
+  CMD_ENABLE = 1
+};
+
+bool enabled = false;
+
+void setup() {
+  pinMode(BUTTON_PIN, INPUT_PULLUP);
+
+  radio.begin();
+  radio.setPALevel(RF24_PA_LOW);
+  radio.setDataRate(RF24_250KBPS);
+  radio.openWritingPipe(ADDRESS);
+  radio.openReadingPipe(1, ADDRESS);
+  radio.startListening();
+}
+
+void loop() {
+  if (radio.available()) {
+    uint8_t cmd;
+    radio.read(&cmd, sizeof(cmd));
+    enabled = (cmd == CMD_ENABLE);
+  }
+
+  if (enabled && digitalRead(BUTTON_PIN) == LOW) {
+    radio.stopListening();
+    uint8_t msg = 4; // This node's ID
+    radio.write(&msg, sizeof(msg));
+    radio.startListening();
+    enabled = false;
+    delay(50);
+  }
+}
+


### PR DESCRIPTION
## Summary
- add main controller sketch that listens for four NRF24L01 remotes and manages LEDs
- add four remote button sketches that send their ID on press and respect enable/disable commands
- document the quiz-style system and wiring assumptions in README

## Testing
- `pre-commit run --files README.md src/main_controller/main_controller.ino src/remote_button1/remote_button1.ino src/remote_button2/remote_button2.ino src/remote_button3/remote_button3.ino src/remote_button4/remote_button4.ino` *(fails: command not found: pre-commit)*

------
https://chatgpt.com/codex/tasks/task_e_68a42c50f06c8328b2995863334f6aef