### PR TITLE
Port quiz buzzer to ESP32 with ESP-NOW

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
 # 4 Button Quiz System
 
 This repository contains Arduino sketches for a simple quiz-style button system using
-nRF24L01 radios.
+ESP32 modules communicating over the ESP-NOW protocol.
 
 ## Components
 
 - Four battery-powered remote units (`remote_button1` to `remote_button4`).
-  Each remote has a single push button and an nRF24L01 module.
-- One main controller (`main_controller`) with four LEDs and a reset button.
+  Each remote is an ESP32 with a single push button.
+- One main controller (`main_controller`) using an ESP32 with four LEDs and a reset
+  button.
 
 ## Behaviour
 
@@ -20,7 +21,12 @@ nRF24L01 radios.
 Remote sketches ignore button presses until an enable command is received from
 the main controller, which helps conserve battery power.
 
-Upload the appropriate sketch to each Arduino Nano. All sketches assume the
-nRF24L01 is connected with CE on pin 9 and CSN on pin 10.
+Each remote sketch contains a `MAIN_MAC` array that must be set to the MAC address
+of the main controller. The main controller sketch contains a `REMOTE_MACS`
+array that must be populated with the MAC addresses of all remotes. You can obtain
+these addresses by running `WiFi.macAddress()` on each ESP32.
+
+Upload the appropriate sketch to each ESP32 using the Arduino IDE or
+`arduino-cli`.
 
 

--- a/src/remote_button1/remote_button1.ino
+++ b/src/remote_button1/remote_button1.ino
@@ -1,13 +1,12 @@
-#include <RF24.h>
+#include <esp_now.h>
+#include <WiFi.h>
 
-// nRF24L01 pins: CE on 9, CSN on 10
-RF24 radio(9, 10);
+// Replace with your main controller's MAC address
+uint8_t MAIN_MAC[6] = {0x24, 0x6F, 0x28, 0xAA, 0xBB, 0xCC};
 
-const byte ADDRESS[6] = "BTN1"; // Unique pipe address for this node
-
+const uint8_t NODE_ID = 1;
 const int BUTTON_PIN = 2;
 
-// Commands
 enum Command : uint8_t {
   CMD_DISABLE = 0,
   CMD_ENABLE = 1
@@ -15,39 +14,44 @@ enum Command : uint8_t {
 
 bool enabled = false;
 
+void onDataRecv(const uint8_t *mac, const uint8_t *incomingData, int len) {
+  if (len == 1) {
+    enabled = (incomingData[0] == CMD_ENABLE);
+    Serial.print("Received command: ");
+    Serial.println(enabled ? "ENABLE" : "DISABLE");
+  }
+}
+
 void setup() {
-  Serial.begin(9600);
+  Serial.begin(115200);
   pinMode(BUTTON_PIN, INPUT_PULLUP);
 
-  radio.begin();
-  radio.setPALevel(RF24_PA_LOW);
-  radio.setDataRate(RF24_250KBPS);
-  radio.openWritingPipe(ADDRESS);
-  radio.openReadingPipe(1, ADDRESS);
-  radio.startListening();
+  WiFi.mode(WIFI_STA);
+  if (esp_now_init() != ESP_OK) {
+    Serial.println("Error initializing ESP-NOW");
+    return;
+  }
+
+  esp_now_register_recv_cb(onDataRecv);
+
+  esp_now_peer_info_t peerInfo{};
+  memcpy(peerInfo.peer_addr, MAIN_MAC, 6);
+  peerInfo.channel = 0;
+  peerInfo.encrypt = false;
+  if (esp_now_add_peer(&peerInfo) != ESP_OK) {
+    Serial.println("Failed to add peer");
+    return;
+  }
+
   Serial.println("Remote button 1 ready");
 }
 
 void loop() {
-  // Check for enable/disable commands from the main controller
-  if (radio.available()) {
-    uint8_t cmd;
-    radio.read(&cmd, sizeof(cmd));
-    enabled = (cmd == CMD_ENABLE);
-    Serial.print("Received command: ");
-    Serial.println(enabled ? "ENABLE" : "DISABLE");
-  }
-
-  // When enabled, report the button press once
   if (enabled && digitalRead(BUTTON_PIN) == LOW) {
-    Serial.println("Button pressed");
-    radio.stopListening();
-    uint8_t msg = 1; // This node's ID
-    Serial.println("Sending ID 1");
-    bool ok = radio.write(&msg, sizeof(msg));
-    Serial.println(ok ? "Send success" : "Send failed");
-    radio.startListening();
-    enabled = false; // ignore further presses until re-enabled
+    uint8_t msg = NODE_ID;
+    esp_err_t result = esp_now_send(MAIN_MAC, &msg, sizeof(msg));
+    Serial.println(result == ESP_OK ? "Send success" : "Send failed");
+    enabled = false;
     delay(50); // basic debounce
   }
 }

--- a/src/remote_button2/remote_button2.ino
+++ b/src/remote_button2/remote_button2.ino
@@ -1,9 +1,10 @@
-#include <RF24.h>
+#include <esp_now.h>
+#include <WiFi.h>
 
-RF24 radio(9, 10);
+// Replace with your main controller's MAC address
+uint8_t MAIN_MAC[6] = {0x24, 0x6F, 0x28, 0xAA, 0xBB, 0xCC};
 
-const byte ADDRESS[6] = "BTN2"; // Unique pipe address for this node
-
+const uint8_t NODE_ID = 2;
 const int BUTTON_PIN = 2;
 
 enum Command : uint8_t {
@@ -13,36 +14,43 @@ enum Command : uint8_t {
 
 bool enabled = false;
 
+void onDataRecv(const uint8_t *mac, const uint8_t *incomingData, int len) {
+  if (len == 1) {
+    enabled = (incomingData[0] == CMD_ENABLE);
+    Serial.print("Received command: ");
+    Serial.println(enabled ? "ENABLE" : "DISABLE");
+  }
+}
+
 void setup() {
-  Serial.begin(9600);
+  Serial.begin(115200);
   pinMode(BUTTON_PIN, INPUT_PULLUP);
 
-  radio.begin();
-  radio.setPALevel(RF24_PA_LOW);
-  radio.setDataRate(RF24_250KBPS);
-  radio.openWritingPipe(ADDRESS);
-  radio.openReadingPipe(1, ADDRESS);
-  radio.startListening();
+  WiFi.mode(WIFI_STA);
+  if (esp_now_init() != ESP_OK) {
+    Serial.println("Error initializing ESP-NOW");
+    return;
+  }
+
+  esp_now_register_recv_cb(onDataRecv);
+
+  esp_now_peer_info_t peerInfo{};
+  memcpy(peerInfo.peer_addr, MAIN_MAC, 6);
+  peerInfo.channel = 0;
+  peerInfo.encrypt = false;
+  if (esp_now_add_peer(&peerInfo) != ESP_OK) {
+    Serial.println("Failed to add peer");
+    return;
+  }
+
   Serial.println("Remote button 2 ready");
 }
 
 void loop() {
-  if (radio.available()) {
-    uint8_t cmd;
-    radio.read(&cmd, sizeof(cmd));
-    enabled = (cmd == CMD_ENABLE);
-    Serial.print("Received command: ");
-    Serial.println(enabled ? "ENABLE" : "DISABLE");
-  }
-
   if (enabled && digitalRead(BUTTON_PIN) == LOW) {
-    Serial.println("Button pressed");
-    radio.stopListening();
-    uint8_t msg = 2; // This node's ID
-    Serial.println("Sending ID 2");
-    bool ok = radio.write(&msg, sizeof(msg));
-    Serial.println(ok ? "Send success" : "Send failed");
-    radio.startListening();
+    uint8_t msg = NODE_ID;
+    esp_err_t result = esp_now_send(MAIN_MAC, &msg, sizeof(msg));
+    Serial.println(result == ESP_OK ? "Send success" : "Send failed");
     enabled = false;
     delay(50);
   }

--- a/src/remote_button4/remote_button4.ino
+++ b/src/remote_button4/remote_button4.ino
@@ -1,9 +1,10 @@
-#include <RF24.h>
+#include <esp_now.h>
+#include <WiFi.h>
 
-RF24 radio(9, 10);
+// Replace with your main controller's MAC address
+uint8_t MAIN_MAC[6] = {0x24, 0x6F, 0x28, 0xAA, 0xBB, 0xCC};
 
-const byte ADDRESS[6] = "BTN4"; // Unique pipe address for this node
-
+const uint8_t NODE_ID = 4;
 const int BUTTON_PIN = 2;
 
 enum Command : uint8_t {
@@ -13,36 +14,43 @@ enum Command : uint8_t {
 
 bool enabled = false;
 
+void onDataRecv(const uint8_t *mac, const uint8_t *incomingData, int len) {
+  if (len == 1) {
+    enabled = (incomingData[0] == CMD_ENABLE);
+    Serial.print("Received command: ");
+    Serial.println(enabled ? "ENABLE" : "DISABLE");
+  }
+}
+
 void setup() {
-  Serial.begin(9600);
+  Serial.begin(115200);
   pinMode(BUTTON_PIN, INPUT_PULLUP);
 
-  radio.begin();
-  radio.setPALevel(RF24_PA_LOW);
-  radio.setDataRate(RF24_250KBPS);
-  radio.openWritingPipe(ADDRESS);
-  radio.openReadingPipe(1, ADDRESS);
-  radio.startListening();
+  WiFi.mode(WIFI_STA);
+  if (esp_now_init() != ESP_OK) {
+    Serial.println("Error initializing ESP-NOW");
+    return;
+  }
+
+  esp_now_register_recv_cb(onDataRecv);
+
+  esp_now_peer_info_t peerInfo{};
+  memcpy(peerInfo.peer_addr, MAIN_MAC, 6);
+  peerInfo.channel = 0;
+  peerInfo.encrypt = false;
+  if (esp_now_add_peer(&peerInfo) != ESP_OK) {
+    Serial.println("Failed to add peer");
+    return;
+  }
+
   Serial.println("Remote button 4 ready");
 }
 
 void loop() {
-  if (radio.available()) {
-    uint8_t cmd;
-    radio.read(&cmd, sizeof(cmd));
-    enabled = (cmd == CMD_ENABLE);
-    Serial.print("Received command: ");
-    Serial.println(enabled ? "ENABLE" : "DISABLE");
-  }
-
   if (enabled && digitalRead(BUTTON_PIN) == LOW) {
-    Serial.println("Button pressed");
-    radio.stopListening();
-    uint8_t msg = 4; // This node's ID
-    Serial.println("Sending ID 4");
-    bool ok = radio.write(&msg, sizeof(msg));
-    Serial.println(ok ? "Send success" : "Send failed");
-    radio.startListening();
+    uint8_t msg = NODE_ID;
+    esp_err_t result = esp_now_send(MAIN_MAC, &msg, sizeof(msg));
+    Serial.println(result == ESP_OK ? "Send success" : "Send failed");
     enabled = false;
     delay(50);
   }


### PR DESCRIPTION
## Summary
- Swap nRF24L01 communication for ESP-NOW across all sketches
- Implement ESP32 main controller broadcasting enable/disable and tracking winners
- Document new ESP32 setup and MAC address configuration

## Testing
- `arduino-cli version` *(fails: command not found)*
- `apt-get install -y arduino-cli` *(fails: Unable to locate package)*
- `curl -fsSL https://raw.githubusercontent.com/arduino/arduino-cli/master/install.sh | sh` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a58220078c832884e67ee2fe5f179e