### PR TITLE
Add startup button check and disable acknowledgement

### DIFF
--- a/src/remote_button2/remote_button2.ino
+++ b/src/remote_button2/remote_button2.ino
@@ -9,16 +9,31 @@ const int BUTTON_PIN = 2;
 
 enum Command : uint8_t {
   CMD_DISABLE = 0,
-  CMD_ENABLE = 1
+  CMD_ENABLE = 1,
+  CMD_CHECK = 2,
+  CMD_DONE = 3
 };
+
+const uint8_t NODE_MSG_BASE = 10;
 
 bool enabled = false;
 
 void onDataRecv(const uint8_t *mac, const uint8_t *incomingData, int len) {
   if (len == 1) {
-    enabled = (incomingData[0] == CMD_ENABLE);
-    Serial.print("Received command: ");
-    Serial.println(enabled ? "ENABLE" : "DISABLE");
+    uint8_t cmd = incomingData[0];
+    if (cmd == CMD_ENABLE) {
+      enabled = true;
+      Serial.println("Received command: ENABLE");
+    } else if (cmd == CMD_DISABLE) {
+      enabled = false;
+      Serial.println("Received command: DISABLE");
+      uint8_t done = CMD_DONE;
+      esp_now_send(mac, &done, sizeof(done));
+    } else if (cmd == CMD_CHECK) {
+      Serial.println("Received command: CHECK");
+      uint8_t resp = CMD_CHECK;
+      esp_now_send(mac, &resp, sizeof(resp));
+    }
   }
 }
 
@@ -47,12 +62,15 @@ void setup() {
 }
 
 void loop() {
+  static unsigned long lastSend = 0;
   if (enabled && digitalRead(BUTTON_PIN) == LOW) {
-    uint8_t msg = NODE_ID;
-    esp_err_t result = esp_now_send(MAIN_MAC, &msg, sizeof(msg));
-    Serial.println(result == ESP_OK ? "Send success" : "Send failed");
-    enabled = false;
-    delay(50);
+    unsigned long now = millis();
+    if (now - lastSend > 100) {
+      uint8_t msg = NODE_MSG_BASE + NODE_ID;
+      esp_err_t result = esp_now_send(MAIN_MAC, &msg, sizeof(msg));
+      Serial.println(result == ESP_OK ? "Send success" : "Send failed");
+      lastSend = now;
+    }
   }
 }
 

--- a/src/remote_button3/remote_button3.ino
+++ b/src/remote_button3/remote_button3.ino
@@ -9,16 +9,31 @@ const int BUTTON_PIN = 2;
 
 enum Command : uint8_t {
   CMD_DISABLE = 0,
-  CMD_ENABLE = 1
+  CMD_ENABLE = 1,
+  CMD_CHECK = 2,
+  CMD_DONE = 3
 };
+
+const uint8_t NODE_MSG_BASE = 10;
 
 bool enabled = false;
 
 void onDataRecv(const uint8_t *mac, const uint8_t *incomingData, int len) {
   if (len == 1) {
-    enabled = (incomingData[0] == CMD_ENABLE);
-    Serial.print("Received command: ");
-    Serial.println(enabled ? "ENABLE" : "DISABLE");
+    uint8_t cmd = incomingData[0];
+    if (cmd == CMD_ENABLE) {
+      enabled = true;
+      Serial.println("Received command: ENABLE");
+    } else if (cmd == CMD_DISABLE) {
+      enabled = false;
+      Serial.println("Received command: DISABLE");
+      uint8_t done = CMD_DONE;
+      esp_now_send(mac, &done, sizeof(done));
+    } else if (cmd == CMD_CHECK) {
+      Serial.println("Received command: CHECK");
+      uint8_t resp = CMD_CHECK;
+      esp_now_send(mac, &resp, sizeof(resp));
+    }
   }
 }
 
@@ -47,12 +62,15 @@ void setup() {
 }
 
 void loop() {
+  static unsigned long lastSend = 0;
   if (enabled && digitalRead(BUTTON_PIN) == LOW) {
-    uint8_t msg = NODE_ID;
-    esp_err_t result = esp_now_send(MAIN_MAC, &msg, sizeof(msg));
-    Serial.println(result == ESP_OK ? "Send success" : "Send failed");
-    enabled = false;
-    delay(50);
+    unsigned long now = millis();
+    if (now - lastSend > 100) {
+      uint8_t msg = NODE_MSG_BASE + NODE_ID;
+      esp_err_t result = esp_now_send(MAIN_MAC, &msg, sizeof(msg));
+      Serial.println(result == ESP_OK ? "Send success" : "Send failed");
+      lastSend = now;
+    }
   }
 }
 

--- a/src/remote_button4/remote_button4.ino
+++ b/src/remote_button4/remote_button4.ino
@@ -9,16 +9,31 @@ const int BUTTON_PIN = 2;
 
 enum Command : uint8_t {
   CMD_DISABLE = 0,
-  CMD_ENABLE = 1
+  CMD_ENABLE = 1,
+  CMD_CHECK = 2,
+  CMD_DONE = 3
 };
+
+const uint8_t NODE_MSG_BASE = 10;
 
 bool enabled = false;
 
 void onDataRecv(const uint8_t *mac, const uint8_t *incomingData, int len) {
   if (len == 1) {
-    enabled = (incomingData[0] == CMD_ENABLE);
-    Serial.print("Received command: ");
-    Serial.println(enabled ? "ENABLE" : "DISABLE");
+    uint8_t cmd = incomingData[0];
+    if (cmd == CMD_ENABLE) {
+      enabled = true;
+      Serial.println("Received command: ENABLE");
+    } else if (cmd == CMD_DISABLE) {
+      enabled = false;
+      Serial.println("Received command: DISABLE");
+      uint8_t done = CMD_DONE;
+      esp_now_send(mac, &done, sizeof(done));
+    } else if (cmd == CMD_CHECK) {
+      Serial.println("Received command: CHECK");
+      uint8_t resp = CMD_CHECK;
+      esp_now_send(mac, &resp, sizeof(resp));
+    }
   }
 }
 
@@ -47,12 +62,15 @@ void setup() {
 }
 
 void loop() {
+  static unsigned long lastSend = 0;
   if (enabled && digitalRead(BUTTON_PIN) == LOW) {
-    uint8_t msg = NODE_ID;
-    esp_err_t result = esp_now_send(MAIN_MAC, &msg, sizeof(msg));
-    Serial.println(result == ESP_OK ? "Send success" : "Send failed");
-    enabled = false;
-    delay(50);
+    unsigned long now = millis();
+    if (now - lastSend > 100) {
+      uint8_t msg = NODE_MSG_BASE + NODE_ID;
+      esp_err_t result = esp_now_send(MAIN_MAC, &msg, sizeof(msg));
+      Serial.println(result == ESP_OK ? "Send success" : "Send failed");
+      lastSend = now;
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- add command types and node message base to separate button presses from control traffic
- implement startup check that pings each remote button and confirms availability with LED feedback
- ensure remotes continue sending press messages until disabled and acknowledge disable
- main controller keeps broadcasting disable until all remotes reply done

## Testing
- `arduino-cli version` *(fails: command not found)*
- `curl -fsSL https://raw.githubusercontent.com/arduino/arduino-cli/master/install.sh | sh` *(fails: CONNECT tunnel failed: 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a6134b7718832885d15370458bbbd4