### PR TITLE
Use remote LEDs only for wins

### DIFF
--- a/src/remote_button1/remote_button1.ino
+++ b/src/remote_button1/remote_button1.ino
@@ -97,8 +97,7 @@ void onRecv(const esp_now_recv_info *info, const uint8_t *data, int len) {
       sendToMain(HELLO_ACK);
       break;
     case HELLO_ACK:
-      // quick visual confirm
-      digitalWrite(LED_PIN, HIGH); delay(60); digitalWrite(LED_PIN, LOW);
+      // no LED feedback; LED reserved for winner indication
       break;
     case ARM:
       armed  = true;
@@ -111,8 +110,6 @@ void onRecv(const esp_now_recv_info *info, const uint8_t *data, int len) {
       winnerId = m.payload8;
       if (winnerId == NODE_ID) {
         digitalWrite(LED_PIN, HIGH); // hold until DISABLE
-      } else {
-        blink(2, 50, 50);
       }
       break;
     case DISABLE:

--- a/src/remote_button2/remote_button2.ino
+++ b/src/remote_button2/remote_button2.ino
@@ -97,8 +97,7 @@ void onRecv(const esp_now_recv_info *info, const uint8_t *data, int len) {
       sendToMain(HELLO_ACK);
       break;
     case HELLO_ACK:
-      // quick visual confirm
-      digitalWrite(LED_PIN, HIGH); delay(60); digitalWrite(LED_PIN, LOW);
+      // no LED feedback; LED reserved for winner indication
       break;
     case ARM:
       armed  = true;
@@ -111,8 +110,6 @@ void onRecv(const esp_now_recv_info *info, const uint8_t *data, int len) {
       winnerId = m.payload8;
       if (winnerId == NODE_ID) {
         digitalWrite(LED_PIN, HIGH); // hold until DISABLE
-      } else {
-        blink(2, 50, 50);
       }
       break;
     case DISABLE:

--- a/src/remote_button3/remote_button3.ino
+++ b/src/remote_button3/remote_button3.ino
@@ -97,8 +97,7 @@ void onRecv(const esp_now_recv_info *info, const uint8_t *data, int len) {
       sendToMain(HELLO_ACK);
       break;
     case HELLO_ACK:
-      // quick visual confirm
-      digitalWrite(LED_PIN, HIGH); delay(60); digitalWrite(LED_PIN, LOW);
+      // no LED feedback; LED reserved for winner indication
       break;
     case ARM:
       armed  = true;
@@ -111,8 +110,6 @@ void onRecv(const esp_now_recv_info *info, const uint8_t *data, int len) {
       winnerId = m.payload8;
       if (winnerId == NODE_ID) {
         digitalWrite(LED_PIN, HIGH); // hold until DISABLE
-      } else {
-        blink(2, 50, 50);
       }
       break;
     case DISABLE:

--- a/src/remote_button4/remote_button4.ino
+++ b/src/remote_button4/remote_button4.ino
@@ -97,8 +97,7 @@ void onRecv(const esp_now_recv_info *info, const uint8_t *data, int len) {
       sendToMain(HELLO_ACK);
       break;
     case HELLO_ACK:
-      // quick visual confirm
-      digitalWrite(LED_PIN, HIGH); delay(60); digitalWrite(LED_PIN, LOW);
+      // no LED feedback; LED reserved for winner indication
       break;
     case ARM:
       armed  = true;
@@ -111,8 +110,6 @@ void onRecv(const esp_now_recv_info *info, const uint8_t *data, int len) {
       winnerId = m.payload8;
       if (winnerId == NODE_ID) {
         digitalWrite(LED_PIN, HIGH); // hold until DISABLE
-      } else {
-        blink(2, 50, 50);
       }
       break;
     case DISABLE:


### PR DESCRIPTION
## Summary
- Stop using remote LEDs for communication feedback
- Light the remote's LED only when that remote wins

## Testing
- ⚠️ `curl -fsSL https://raw.githubusercontent.com/arduino/arduino-cli/master/install.sh | sh` (403: CONNECT tunnel failed)
- ⚠️ `g++ -x c++ -fsyntax-only src/remote_button1/remote_button1.ino` (missing `esp_now.h`)


------
https://chatgpt.com/codex/tasks/task_e_68ad8d9144e08328b3eafecf5eb9b598